### PR TITLE
fix: in ssh_process, we exit(1) only if the exit code of the ssh command is not 0

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,7 +105,8 @@ def ssh_process(ssh, input_ssh):
     err = err.strip() if err is not None else None
     if err:
         print(f"Error: \n{err}")
-        sys.exit(1)
+        if out is None:
+            sys.exit(1)
         
     pass
 

--- a/app.py
+++ b/app.py
@@ -97,7 +97,6 @@ def ssh_process(ssh, input_ssh):
     stdin, stdout, stderr = ssh.exec_command(command_str)
     
     ssh_exit_status = stdout.channel.recv_exit_status()
-    print(f"ssh exit status: {ssh_exit_status}")
     
     out = "".join(stdout.readlines())
     out = out.strip() if out is not None else None
@@ -108,8 +107,7 @@ def ssh_process(ssh, input_ssh):
     err = err.strip() if err is not None else None
     if err:
         print(f"Error: \n{err}")
-        if out is None:
-            sys.exit(1)
+    
     if  ssh_exit_status != 0:
         print(f"ssh exit status: {ssh_exit_status}")
         sys.exit(1)

--- a/app.py
+++ b/app.py
@@ -96,6 +96,9 @@ def ssh_process(ssh, input_ssh):
 
     stdin, stdout, stderr = ssh.exec_command(command_str)
     
+    ssh_exit_status = stdout.channel.recv_exit_status()
+    print(f"ssh exit status: {ssh_exit_status}")
+    
     out = "".join(stdout.readlines())
     out = out.strip() if out is not None else None
     if out:
@@ -107,6 +110,9 @@ def ssh_process(ssh, input_ssh):
         print(f"Error: \n{err}")
         if out is None:
             sys.exit(1)
+    if  ssh_exit_status != 0:
+        print(f"ssh exit status: {ssh_exit_status}")
+        sys.exit(1)
         
     pass
 


### PR DESCRIPTION
I think this new PR improve my first one, taking into account @ghost-void 's pertinent remark.
I tested it in my use case, with and without a ssh command failing.
Don't hesitate to criticize or modify or reject !